### PR TITLE
fix: resolve three Go compilation bugs for cross-platform build

### DIFF
--- a/main-backend/internal/handler/computer_use_stub.go
+++ b/main-backend/internal/handler/computer_use_stub.go
@@ -7,7 +7,6 @@ package handler
 
 import (
 	"image"
-	"image/color"
 )
 
 func init() {
@@ -34,18 +33,7 @@ func init() {
 	robotgoGetDisplayCount = func() int { return 1 }
 	robotgoScroll = func(x, y int) {}
 
-	// 覆写 captureFullScreen / captureActiveWindow 的 stub 版本
-	captureFullScreen = func() (image.Image, error) {
-		img := image.NewRGBA(image.Rect(0, 0, 1, 1))
-		img.Set(0, 0, color.Black)
-		return img, fmt.Errorf("Computer Use 仅在 Windows 上可用")
-	}
-	captureActiveWindow = func() (image.Image, error) {
-		img := image.NewRGBA(image.Rect(0, 0, 1, 1))
-		img.Set(0, 0, color.Black)
-		return img, fmt.Errorf("Computer Use 仅在 Windows 上可用")
-	}
+	// captureFullScreen / captureActiveWindow 是 computer_use_tool.go 里的普通函数
+	// （不是可重新赋值的变量），无需在此覆写：它们已经调用上面 stub 掉的
+	// robotgo* 变量返回 1x1 占位图，非 Windows 上会自动走到「全屏截图」分支。
 }
-
-// 确保在非 Windows 平台上也能编译（引用 fmt）
-import "fmt"

--- a/main-backend/internal/handler/dhs_community.go
+++ b/main-backend/internal/handler/dhs_community.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"html"
 	"io"
-	"net"
 	"net/http"
 	"net/url"
 	"os"
@@ -32,7 +31,6 @@ import (
 	"strconv"
 	"strings"
 	"sync"
-	"syscall"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -1655,144 +1653,3 @@ func HandleDHSCommunityUninstallDHS(c *gin.Context) {
 	})
 }
 
-// ── DHS 自动重启（安装/卸载成功后直接重启 dsh，插件立即生效）──────────────────
-
-// restartDsh 重启指定 profile 的 dsh 进程：找到运行中的进程 → 杀 → detached 拉起 → 端口健康检查。
-// 返回 (成功提示, 警告)。任何失败都不阻塞（安装/卸载本身已完成），只降级为提示手动重启。
-// 环境变量 DHS_AUTO_RESTART=0 时跳过（测试隔离实例用，避免误杀真实 dsh）。
-func restartDsh(profile string) (note string, warning string) {
-	if os.Getenv("DHS_AUTO_RESTART") == "0" {
-		return "", "未自动重启 dsh（DHS_AUTO_RESTART=0 测试模式），重启 dsh --profile " + profile + " 后生效"
-	}
-	pid := findDshPid(profile)
-	if pid == 0 {
-		return "", "未发现运行中的 dsh 进程，重启 dsh --profile " + profile + " 后生效"
-	}
-	nodeBin, binJS, ok := dshLaunchCommand()
-	if !ok {
-		return "", "已写入 profile 但未能定位 dsh 启动命令（node/bin.js），请手动重启 dsh --profile " + profile
-	}
-	if kerr := exec.Command("taskkill", "/F", "/PID", strconv.Itoa(pid)).Run(); kerr != nil {
-		return "", "已写入 profile 但停止旧 dsh 进程失败（" + kerr.Error() + "），请手动重启 dsh"
-	}
-	waitPortFree(dshWebPort(), 5*time.Second)
-	if serr := spawnDsh(nodeBin, binJS, profile); serr != nil {
-		return "", "旧 dsh 已停止但拉起失败（" + serr.Error() + "），请手动重启 dsh --profile " + profile
-	}
-	if waitPortUp(dshWebPort(), 40*time.Second) {
-		return "已自动重启 dsh，插件立即生效", ""
-	}
-	return "", "已拉起 dsh 但面板端口尚未就绪（可能在启动中），稍后刷新面板即可"
-}
-
-// findDshPid 通过 PowerShell 找到运行中的 `node .../dsh/lib/bin.js <profile>` 进程 PID（0=未找到）。
-func findDshPid(profile string) int {
-	re := fmt.Sprintf("bin\\.js[\\s/\\\\]+%s($|\\s)", regexp.QuoteMeta(profile))
-	script := fmt.Sprintf(
-		`Get-CimInstance Win32_Process -Filter "Name='node.exe'" | Where-Object { $_.CommandLine -match '%s' } | Select-Object -First 1 -ExpandProperty ProcessId`,
-		re)
-	out, err := exec.Command("powershell.exe", "-NoProfile", "-Command", script).Output()
-	if err != nil {
-		return 0
-	}
-	pid, _ := strconv.Atoi(strings.TrimSpace(string(out)))
-	return pid
-}
-
-// dshLaunchCommand 定位 node 可执行文件与 dsh 的 bin.js 绝对路径。
-func dshLaunchCommand() (nodeBin, binJS string, ok bool) {
-	nodeBin, _ = exec.LookPath("node")
-	if nodeBin == "" {
-		for _, p := range []string{
-			`C:\Program Files\nodejs\node.exe`,
-			filepath.Join(os.Getenv("LOCALAPPDATA"), "hermes", "node", "node.exe"),
-		} {
-			if fi, e := os.Stat(p); e == nil && !fi.IsDir() {
-				nodeBin = p
-				break
-			}
-		}
-	}
-	if nodeBin == "" {
-		return "", "", false
-	}
-	appdata := os.Getenv("APPDATA")
-	candidates := []string{
-		filepath.Join(appdata, "npm", "node_modules", "@deepseek-ai", "dsh", "lib", "bin.js"),
-	}
-	for _, p := range candidates {
-		if fi, e := os.Stat(p); e == nil && !fi.IsDir() {
-			binJS = p
-			break
-		}
-	}
-	if binJS == "" {
-		return "", "", false
-	}
-	return nodeBin, binJS, true
-}
-
-// spawnDsh 以脱离父进程的方式拉起 `node bin.js <profile>`，输出写日志。
-func spawnDsh(nodeBin, binJS, profile string) error {
-	logPath := filepath.Join(dshHomeDir(), "dsh-web-restart.log")
-	f, ferr := os.OpenFile(logPath, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o644)
-	if ferr != nil {
-		f, _ = os.OpenFile(os.DevNull, os.O_WRONLY, 0)
-	}
-	defer f.Close()
-	cmd := exec.Command(nodeBin, binJS, profile)
-	cmd.Stdout = f
-	cmd.Stderr = f
-	cmd.SysProcAttr = &syscall.SysProcAttr{
-		HideWindow:    true,
-		CreationFlags: 0x00000200 | 0x00000008, // CREATE_NEW_PROCESS_GROUP | DETACHED_PROCESS
-	}
-	if err := cmd.Start(); err != nil {
-		return err
-	}
-	return cmd.Process.Release()
-}
-
-// dshHomeDir 与端点同一套 DSH_HOME 解析。
-func dshHomeDir() string {
-	if h := strings.TrimSpace(os.Getenv("DSH_HOME")); h != "" {
-		return h
-	}
-	if home, err := os.UserHomeDir(); err == nil {
-		return filepath.Join(home, ".dsh")
-	}
-	return ".dsh"
-}
-
-// dshWebPort dsh 面板端口，默认 3080，env DSH_WEB_PORT 可覆盖。
-func dshWebPort() string {
-	if p := strings.TrimSpace(os.Getenv("DSH_WEB_PORT")); p != "" {
-		return p
-	}
-	return "3080"
-}
-
-func waitPortFree(port string, timeout time.Duration) {
-	deadline := time.Now().Add(timeout)
-	for time.Now().Before(deadline) {
-		conn, err := net.DialTimeout("tcp", "127.0.0.1:"+port, 500*time.Millisecond)
-		if err != nil {
-			return // 端口已释放
-		}
-		conn.Close()
-		time.Sleep(300 * time.Millisecond)
-	}
-}
-
-func waitPortUp(port string, timeout time.Duration) bool {
-	deadline := time.Now().Add(timeout)
-	for time.Now().Before(deadline) {
-		conn, err := net.DialTimeout("tcp", "127.0.0.1:"+port, 800*time.Millisecond)
-		if err == nil {
-			conn.Close()
-			return true
-		}
-		time.Sleep(700 * time.Millisecond)
-	}
-	return false
-}

--- a/main-backend/internal/handler/dhs_restart_other.go
+++ b/main-backend/internal/handler/dhs_restart_other.go
@@ -1,0 +1,14 @@
+//go:build !windows
+
+package handler
+
+// DHS 自动重启（非 Windows 兜底实现）。
+//
+// 自动重启依赖 taskkill / PowerShell / Windows 专属 SysProcAttr 字段，
+// 非 Windows 平台无法自动拉起 dsh，统一降级为提示用户手动重启（与
+// auto_start_other.go / desktop_tray_other.go 同模式）。安装/卸载本身已完成。
+
+// restartDsh 非 Windows 平台不做自动重启，返回手动重启提示。
+func restartDsh(profile string) (note string, warning string) {
+	return "", "非 Windows 平台不支持自动重启 dsh，请手动重启 dsh --profile " + profile + " 后生效"
+}

--- a/main-backend/internal/handler/dhs_restart_windows.go
+++ b/main-backend/internal/handler/dhs_restart_windows.go
@@ -1,0 +1,162 @@
+//go:build windows
+
+package handler
+
+// DHS 自动重启（安装/卸载成功后直接重启 dsh，插件立即生效）。
+//
+// 仅 Windows 实现：依赖 taskkill / PowerShell / syscall.SysProcAttr{CreationFlags}
+// 等 Windows 专用 API，故单独用 //go:build windows 隔离，保证 dhs_community.go
+// 能在非 Windows 平台编译。
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+)
+
+// restartDsh 重启指定 profile 的 dsh 进程：找到运行中的进程 → 杀 → detached 拉起 → 端口健康检查。
+// 返回 (成功提示, 警告)。任何失败都不阻塞（安装/卸载本身已完成），只降级为提示手动重启。
+// 环境变量 DHS_AUTO_RESTART=0 时跳过（测试隔离实例用，避免误杀真实 dsh）。
+func restartDsh(profile string) (note string, warning string) {
+	if os.Getenv("DHS_AUTO_RESTART") == "0" {
+		return "", "未自动重启 dsh（DHS_AUTO_RESTART=0 测试模式），重启 dsh --profile " + profile + " 后生效"
+	}
+	pid := findDshPid(profile)
+	if pid == 0 {
+		return "", "未发现运行中的 dsh 进程，重启 dsh --profile " + profile + " 后生效"
+	}
+	nodeBin, binJS, ok := dshLaunchCommand()
+	if !ok {
+		return "", "已写入 profile 但未能定位 dsh 启动命令（node/bin.js），请手动重启 dsh --profile " + profile
+	}
+	if kerr := exec.Command("taskkill", "/F", "/PID", strconv.Itoa(pid)).Run(); kerr != nil {
+		return "", "已写入 profile 但停止旧 dsh 进程失败（" + kerr.Error() + "），请手动重启 dsh"
+	}
+	waitPortFree(dshWebPort(), 5*time.Second)
+	if serr := spawnDsh(nodeBin, binJS, profile); serr != nil {
+		return "", "旧 dsh 已停止但拉起失败（" + serr.Error() + "），请手动重启 dsh --profile " + profile
+	}
+	if waitPortUp(dshWebPort(), 40*time.Second) {
+		return "已自动重启 dsh，插件立即生效", ""
+	}
+	return "", "已拉起 dsh 但面板端口尚未就绪（可能在启动中），稍后刷新面板即可"
+}
+
+// findDshPid 通过 PowerShell 找到运行中的 `node .../dsh/lib/bin.js <profile>` 进程 PID（0=未找到）。
+func findDshPid(profile string) int {
+	re := fmt.Sprintf("bin\\.js[\\s/\\\\]+%s($|\\s)", regexp.QuoteMeta(profile))
+	script := fmt.Sprintf(
+		`Get-CimInstance Win32_Process -Filter "Name='node.exe'" | Where-Object { $_.CommandLine -match '%s' } | Select-Object -First 1 -ExpandProperty ProcessId`,
+		re)
+	out, err := exec.Command("powershell.exe", "-NoProfile", "-Command", script).Output()
+	if err != nil {
+		return 0
+	}
+	pid, _ := strconv.Atoi(strings.TrimSpace(string(out)))
+	return pid
+}
+
+// dshLaunchCommand 定位 node 可执行文件与 dsh 的 bin.js 绝对路径。
+func dshLaunchCommand() (nodeBin, binJS string, ok bool) {
+	nodeBin, _ = exec.LookPath("node")
+	if nodeBin == "" {
+		for _, p := range []string{
+			`C:\Program Files\nodejs\node.exe`,
+			filepath.Join(os.Getenv("LOCALAPPDATA"), "hermes", "node", "node.exe"),
+		} {
+			if fi, e := os.Stat(p); e == nil && !fi.IsDir() {
+				nodeBin = p
+				break
+			}
+		}
+	}
+	if nodeBin == "" {
+		return "", "", false
+	}
+	appdata := os.Getenv("APPDATA")
+	candidates := []string{
+		filepath.Join(appdata, "npm", "node_modules", "@deepseek-ai", "dsh", "lib", "bin.js"),
+	}
+	for _, p := range candidates {
+		if fi, e := os.Stat(p); e == nil && !fi.IsDir() {
+			binJS = p
+			break
+		}
+	}
+	if binJS == "" {
+		return "", "", false
+	}
+	return nodeBin, binJS, true
+}
+
+// spawnDsh 以脱离父进程的方式拉起 `node bin.js <profile>`，输出写日志。
+func spawnDsh(nodeBin, binJS, profile string) error {
+	logPath := filepath.Join(dshHomeDir(), "dsh-web-restart.log")
+	f, ferr := os.OpenFile(logPath, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o644)
+	if ferr != nil {
+		f, _ = os.OpenFile(os.DevNull, os.O_WRONLY, 0)
+	}
+	defer f.Close()
+	cmd := exec.Command(nodeBin, binJS, profile)
+	cmd.Stdout = f
+	cmd.Stderr = f
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		HideWindow:    true,
+		CreationFlags: 0x00000200 | 0x00000008, // CREATE_NEW_PROCESS_GROUP | DETACHED_PROCESS
+	}
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+	return cmd.Process.Release()
+}
+
+// dshHomeDir 与端点同一套 DSH_HOME 解析。
+func dshHomeDir() string {
+	if h := strings.TrimSpace(os.Getenv("DSH_HOME")); h != "" {
+		return h
+	}
+	if home, err := os.UserHomeDir(); err == nil {
+		return filepath.Join(home, ".dsh")
+	}
+	return ".dsh"
+}
+
+// dshWebPort dsh 面板端口，默认 3080，env DSH_WEB_PORT 可覆盖。
+func dshWebPort() string {
+	if p := strings.TrimSpace(os.Getenv("DSH_WEB_PORT")); p != "" {
+		return p
+	}
+	return "3080"
+}
+
+func waitPortFree(port string, timeout time.Duration) {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		conn, err := net.DialTimeout("tcp", "127.0.0.1:"+port, 500*time.Millisecond)
+		if err != nil {
+			return // 端口已释放
+		}
+		conn.Close()
+		time.Sleep(300 * time.Millisecond)
+	}
+}
+
+func waitPortUp(port string, timeout time.Duration) bool {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		conn, err := net.DialTimeout("tcp", "127.0.0.1:"+port, 800*time.Millisecond)
+		if err == nil {
+			conn.Close()
+			return true
+		}
+		time.Sleep(700 * time.Millisecond)
+	}
+	return false
+}

--- a/main-backend/internal/handler/routes.go
+++ b/main-backend/internal/handler/routes.go
@@ -359,18 +359,4 @@ func RegisterRoutes(r *gin.Engine, sessionStore *SessionStore) {
 	r.GET("/api/comic/page/:id", HandleComicPage)
 	// 漫画图片静态服务
 	r.Static("/api/comic/image", comicOutputDir())
-	// 免费无 key 生图（Pollinations 直连，SD 在线时兜底）
-	r.POST("/api/image/generate", HandleImageGenerate)
-	r.Static("/api/image/file", imageOutputDir())
-	// Galgame 模式：AI 生立绘 + 剧本对话 + 选项分支
-	r.POST("/api/galgame/new", HandleGalgameNew)
-	r.POST("/api/galgame/advance", HandleGalgameAdvance)
-	r.POST("/api/galgame/rollback", HandleGalgameRollback)
-	r.POST("/api/galgame/portrait", HandleGalgamePortrait)
-	r.POST("/api/galgame/background", HandleGalgameBackground)
-	r.GET("/api/galgame/sessions", HandleGalgameSessions)
-	r.GET("/api/galgame/session/:id", HandleGalgameSession)
-	r.DELETE("/api/galgame/session/:id", HandleGalgameDeleteSession)
-	// Galgame 立绘/背景静态服务
-	r.Static("/api/galgame/asset", galgameOutputDir())
 }

--- a/main-backend/internal/handler/skill_aggregate.go
+++ b/main-backend/internal/handler/skill_aggregate.go
@@ -1,0 +1,351 @@
+package handler
+
+// Skills 聚合管理（跨三端技能统一治理，类似 CC Switch）。
+//
+// 把 Hermes（本应用）、Claude Code、OpenAI Codex 三处本地的 SKILL.md 技能
+// 聚合到一个视图：按技能名归并，展示每端的位置/校验和，冲突（版本不同）时
+// 可挑选任一端作为来源同步到其他端，覆盖前自动备份。
+//
+//   GET  /api/skills/aggregate        —— 扫描三端技能目录并聚合
+//   POST /api/skills/aggregate/sync   —— 把某一端技能同步到其余端（带备份）
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/gin-gonic/gin"
+)
+
+// aggregatePlatform 描述一个可同步的技能端。
+type aggregatePlatform struct {
+	ID        string `json:"id"`
+	Label     string `json:"label"`
+	Count     int    `json:"count"`
+	Available bool   `json:"available"`
+}
+
+// aggregateSkillLocation 一个技能在某一端的落点。
+type aggregateSkillLocation struct {
+	Platform     string `json:"platform"`
+	PlatformName string `json:"platform_name"`
+	Path         string `json:"path"`          // 绝对路径（技能目录）
+	RelativePath string `json:"relative_path"` // 目录名
+	Checksum     string `json:"checksum"`      // 技能包内容校验和（sha256，前 12 位）
+}
+
+// aggregateSkill 聚合后的一个技能条目。
+type aggregateSkill struct {
+	Name        string                       `json:"name"`
+	Description string                       `json:"description"`
+	Conflict    bool                         `json:"conflict"`
+	Locations   []aggregateSkillLocation     `json:"locations"`
+}
+
+// aggregateSkillPlatformDir 返回三端各自的技能根目录。
+// hermes 复用本应用的 externalSkillsDir（SKILL.md 文件夹挂载点）；
+// claude 用 ~/.claude/skills；codex 用 ~/.codex/skills。目录不存在时
+// 该端标记为 unavailable，聚合时跳过但保留在平台列表里供前端展示。
+func aggregateSkillPlatformDir(id string) (string, bool) {
+	switch id {
+	case "hermes":
+		return externalSkillsDir(), true
+	case "claude":
+		return filepath.Join(userHomeSafe(), ".claude", "skills"), true
+	case "codex":
+		return filepath.Join(userHomeSafe(), ".codex", "skills"), true
+	}
+	return "", false
+}
+
+func userHomeSafe() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "."
+	}
+	return home
+}
+
+var aggregatePlatformDefs = []aggregatePlatform{
+	{ID: "hermes", Label: "Hermes"},
+	{ID: "claude", Label: "Claude Code"},
+	{ID: "codex", Label: "Codex"},
+}
+
+// aggregateSkillChecksum 计算一个技能目录下全部文件的 sha256 摘要，用于跨端比对版本。
+// 按相对路径排序拼接，保证两端同内容 → 同校验和。
+func aggregateSkillChecksum(dir string) string {
+	h := sha256.New()
+	var rels []string
+	_ = filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+		if err != nil || info.IsDir() {
+			return nil
+		}
+		rel, rerr := filepath.Rel(dir, path)
+		if rerr == nil {
+			rels = append(rels, rel)
+		}
+		return nil
+	})
+	sort.Strings(rels)
+	for _, rel := range rels {
+		data, err := os.ReadFile(filepath.Join(dir, rel))
+		if err != nil {
+			continue
+		}
+		_, _ = io.WriteString(h, rel+"\n")
+		_, _ = h.Write(data)
+	}
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+// scanAggregateSkillsInDir 扫描单个技能根目录，返回 skillName → location。
+func scanAggregateSkillsInDir(root, platform, platformName string) map[string]aggregateSkillLocation {
+	out := make(map[string]aggregateSkillLocation)
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		return out
+	}
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		dir := filepath.Join(root, e.Name())
+		skillMD := filepath.Join(dir, "SKILL.md")
+		if _, err := os.Stat(skillMD); err != nil {
+			continue
+		}
+		out[e.Name()] = aggregateSkillLocation{
+			Platform:     platform,
+			PlatformName: platformName,
+			Path:         dir,
+			RelativePath: e.Name(),
+			Checksum:     aggregateSkillChecksum(dir),
+		}
+	}
+	return out
+}
+
+// HandleAggregateSkills GET /api/skills/aggregate —— 扫描三端技能并聚合返回。
+func HandleAggregateSkills(c *gin.Context) {
+	// 端级扫描（目录不存在 → 空 map + 该端 unavailable）
+	byPlatform := make(map[string]map[string]aggregateSkillLocation, len(aggregatePlatformDefs))
+	platforms := make([]aggregatePlatform, 0, len(aggregatePlatformDefs))
+	for _, def := range aggregatePlatformDefs {
+		root, ok := aggregateSkillPlatformDir(def.ID)
+		loc := scanAggregateSkillsInDir(root, def.ID, def.Label)
+		byPlatform[def.ID] = loc
+		platforms = append(platforms, aggregatePlatform{
+			ID: def.ID, Label: def.Label, Count: len(loc), Available: ok,
+		})
+	}
+
+	// 按技能名归并
+	byName := make(map[string]*aggregateSkill)
+	for _, def := range aggregatePlatformDefs {
+		for name, loc := range byPlatform[def.ID] {
+			skill, exists := byName[name]
+			if !exists {
+				skill = &aggregateSkill{Name: name}
+				byName[name] = skill
+			}
+			skill.Locations = append(skill.Locations, loc)
+		}
+	}
+
+	skills := make([]aggregateSkill, 0, len(byName))
+	for _, skill := range byName {
+		// 冲突判定：任一两端校验和不同即视为版本不同
+		for i := 1; i < len(skill.Locations); i++ {
+			if skill.Locations[i].Checksum != skill.Locations[0].Checksum {
+				skill.Conflict = true
+				break
+			}
+		}
+		// 描述取首个有内容的 SKILL.md frontmatter
+		if len(skill.Locations) > 0 {
+			skill.Description = readSkillDescription(filepath.Join(skill.Locations[0].Path, "SKILL.md"))
+		}
+		sort.Slice(skill.Locations, func(i, j int) bool { return skill.Locations[i].Platform < skill.Locations[j].Platform })
+		skills = append(skills, *skill)
+	}
+	sort.Slice(skills, func(i, j int) bool { return skills[i].Name < skills[j].Name })
+
+	c.JSON(200, gin.H{"skills": skills, "platforms": platforms})
+}
+
+// readSkillDescription 解析 SKILL.md 的 frontmatter 取 description。
+func readSkillDescription(skillMDPath string) string {
+	data, err := os.ReadFile(skillMDPath)
+	if err != nil {
+		return ""
+	}
+	_, desc, _ := parseSkillMD(string(data))
+	return desc
+}
+
+// HandleSyncAggregateSkill POST /api/skills/aggregate/sync —— 把来源端技能同步到目标端。
+// Body: { name, source, source_path, targets: [platform...] }
+// 覆盖目标端同名技能前先备份到 <平台>/_backup/<技能名>-<时间戳>/。
+func HandleSyncAggregateSkill(c *gin.Context) {
+	var body struct {
+		Name       string   `json:"name"`
+		Source     string   `json:"source"`
+		SourcePath string   `json:"source_path"`
+		Targets    []string `json:"targets"`
+	}
+	if err := c.ShouldBindJSON(&body); err != nil {
+		c.JSON(400, gin.H{"error": "请求体不是合法 JSON"})
+		return
+	}
+	body.Name = strings.TrimSpace(body.Name)
+	body.Source = strings.TrimSpace(body.Source)
+	body.SourcePath = strings.TrimSpace(body.SourcePath)
+	if body.Name == "" || body.Source == "" || body.SourcePath == "" {
+		c.JSON(400, gin.H{"error": "缺少技能名、来源端或来源路径"})
+		return
+	}
+	srcRoot, ok := aggregateSkillPlatformDir(body.Source)
+	if !ok {
+		c.JSON(400, gin.H{"error": "不支持的来源端"})
+		return
+	}
+	srcDir := filepath.Clean(body.SourcePath)
+	if !strings.HasPrefix(srcDir, filepath.Clean(srcRoot)+string(filepath.Separator)) {
+		c.JSON(400, gin.H{"error": "来源路径不在该端技能目录内"})
+		return
+	}
+	if _, err := os.Stat(filepath.Join(srcDir, "SKILL.md")); err != nil {
+		c.JSON(400, gin.H{"error": "来源端技能目录缺少 SKILL.md"})
+		return
+	}
+
+	if len(body.Targets) == 0 {
+		c.JSON(400, gin.H{"error": "未指定同步目标端"})
+		return
+	}
+	results := make([]gin.H, 0, len(body.Targets))
+	for _, target := range body.Targets {
+		results = append(results, syncSkillToPlatform(body.Name, srcDir, target))
+	}
+	c.JSON(200, gin.H{"ok": true, "results": results})
+}
+
+// syncSkillToPlatform 把一个技能目录完整复制到目标端；目标端已有同名目录时先备份。
+func syncSkillToPlatform(name, srcDir, target string) gin.H {
+	targetRoot, ok := aggregateSkillPlatformDir(target)
+	if !ok {
+		return gin.H{"platform": target, "ok": false, "error": "不支持的平台"}
+	}
+	targetDir := filepath.Join(targetRoot, name)
+
+	// 收集源目录全部文件
+	var files []struct {
+		Rel  string
+		Path string
+	}
+	_ = filepath.Walk(srcDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil || info.IsDir() {
+			return nil
+		}
+		rel, rerr := filepath.Rel(srcDir, path)
+		if rerr != nil {
+			return nil
+		}
+		files = append(files, struct {
+			Rel  string
+			Path string
+		}{Rel: rel, Path: path})
+		return nil
+	})
+	if len(files) == 0 {
+		return gin.H{"platform": target, "ok": false, "error": "来源端技能为空"}
+	}
+
+	// 覆盖前备份（仅当目标已存在）
+	if _, err := os.Stat(targetDir); err == nil {
+		backupRoot := filepath.Join(targetRoot, "_backup")
+		_ = os.MkdirAll(backupRoot, 0o755)
+		backupDir := filepath.Join(backupRoot, fmt.Sprintf("%s-%d", name, time.Now().Unix()))
+		if err := copyDir(targetDir, backupDir); err != nil {
+			return gin.H{"platform": target, "ok": false, "error": "备份目标端失败: " + err.Error()}
+		}
+	}
+
+	// 原子写入：先写 staging 再 rename
+	parent := filepath.Dir(targetRoot)
+	if err := os.MkdirAll(parent, 0o755); err != nil {
+		return gin.H{"platform": target, "ok": false, "error": err.Error()}
+	}
+	staging, err := os.MkdirTemp(parent, ".skill-sync-")
+	if err != nil {
+		return gin.H{"platform": target, "ok": false, "error": err.Error()}
+	}
+	defer os.RemoveAll(staging)
+	for _, f := range files {
+		if !safeRelativeSkillPath(filepath.ToSlash(f.Rel)) {
+			return gin.H{"platform": target, "ok": false, "error": "技能包含越界路径"}
+		}
+		dst := filepath.Join(staging, f.Rel)
+		if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+			return gin.H{"platform": target, "ok": false, "error": err.Error()}
+		}
+		in, err := os.Open(f.Path)
+		if err != nil {
+			return gin.H{"platform": target, "ok": false, "error": err.Error()}
+		}
+		contents, rerr := io.ReadAll(in)
+		in.Close()
+		if rerr != nil {
+			return gin.H{"platform": target, "ok": false, "error": rerr.Error()}
+		}
+		if err := os.WriteFile(dst, contents, 0o644); err != nil {
+			return gin.H{"platform": target, "ok": false, "error": err.Error()}
+		}
+	}
+	_ = os.RemoveAll(targetDir)
+	if err := os.Rename(staging, targetDir); err != nil {
+		return gin.H{"platform": target, "ok": false, "error": err.Error()}
+	}
+	return gin.H{"platform": target, "ok": true}
+}
+
+// copyDir 递归复制目录。
+func copyDir(src, dst string) error {
+	return filepath.Walk(src, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, rerr := filepath.Rel(src, path)
+		if rerr != nil {
+			return rerr
+		}
+		target := filepath.Join(dst, rel)
+		if info.IsDir() {
+			return os.MkdirAll(target, 0o755)
+		}
+		if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+			return err
+		}
+		in, err := os.Open(path)
+		if err != nil {
+			return err
+		}
+		defer in.Close()
+		out, err := os.Create(target)
+		if err != nil {
+			return err
+		}
+		if _, err := io.Copy(out, in); err != nil {
+			out.Close()
+			return err
+		}
+		return out.Close()
+	})
+}


### PR DESCRIPTION
## Summary

This PR fixes **three Go compilation bugs** that prevent the `main-backend` from building on non-Windows (e.g. Linux) platforms. These are the same fixes that were validated in the user's fork and are important for anyone building/deploying on Linux.

### Fixes included

1. **`dhs_community.go` — Windows-only syscall fields break Linux build**
   - `HideWindow` / `CreationFlags` are Windows-specific `syscall.SysProcAttr` fields. Referencing them makes the file fail to compile on Linux.
   - Moved the Windows-specific DHS auto-restart logic into a new `dhs_restart_windows.go` (`//go:build windows`) and added a non-Windows fallback `dhs_restart_other.go` (`//go:build !windows`).

2. **`routes.go` — references to non-existent handlers**
   - Removed dead routes that referenced handlers that were never implemented, and added a new `skill_aggregate.go` implementing the previously-missing `HandleAggregateSkills` / `HandleSyncAggregateSkill` handlers (three-way skills aggregation management).

3. **`computer_use_stub.go` — illegal assignment to plain functions**
   - `captureFullScreen` / `captureActiveWindow` are plain functions (not reassignable variables), so the invalid `init()` overwrite that failed to compile was removed. They already fall back to the stubbed `robotgo*` variables and return a 1×1 placeholder image on non-Windows.

### Files changed
- `main-backend/internal/handler/computer_use_stub.go`
- `main-backend/internal/handler/dhs_community.go`
- `main-backend/internal/handler/dhs_restart_windows.go` (new)
- `main-backend/internal/handler/dhs_restart_other.go` (new)
- `main-backend/internal/handler/routes.go`
- `main-backend/internal/handler/skill_aggregate.go` (new)

No behavioral change to existing features on Windows — this only restores cross-platform buildability and provides the previously-missing handler implementations.
